### PR TITLE
chore: auto-discover transform tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,5 +3,6 @@ import type { Config } from "@jest/types";
 const config: Config.InitialOptions = {
   preset: "ts-jest",
   testEnvironment: "node",
+  testMatch: ["<rootDir>/transforms/__tests__/**.test.ts"],
 };
 export default config;

--- a/transforms/__tests__/rewrite-construct-imports.test.ts
+++ b/transforms/__tests__/rewrite-construct-imports.test.ts
@@ -1,19 +1,5 @@
-import { defineTest } from "jscodeshift/src/testUtils";
+import { createTestsForTransform } from "./utils";
 
 describe("rewrite construct imports", () => {
-  defineTest(__dirname, "./rewrite-construct-imports", {}, "rewrite-construct-imports/import-construct", {
-    parser: "ts",
-  });
-  defineTest(__dirname, "./rewrite-construct-imports", {}, "rewrite-construct-imports/import-star", {
-    parser: "ts",
-  });
-  defineTest(__dirname, "./rewrite-construct-imports", {}, "rewrite-construct-imports/import-star-multiple-uses", {
-    parser: "ts",
-  });
-  defineTest(__dirname, "./rewrite-construct-imports", {}, "rewrite-construct-imports/no-import", {
-    parser: "ts",
-  });
-  defineTest(__dirname, "./rewrite-construct-imports", {}, "rewrite-construct-imports/import-star-no-uses", {
-    parser: "ts",
-  });
+  createTestsForTransform("rewrite-construct-imports");
 });

--- a/transforms/__tests__/utils.ts
+++ b/transforms/__tests__/utils.ts
@@ -1,0 +1,11 @@
+import { defineTest } from "jscodeshift/src/testUtils";
+import globby from "globby";
+import path from "path";
+
+export function createTestsForTransform(transform: string): void {
+  globby.sync(path.join(__dirname, "..", "__testfixtures__", `${transform}/*.input.ts`)).forEach((t) => {
+    defineTest(__dirname, `./${transform}`, {}, `${transform}/${path.basename(t).replace(".input.ts", "")}`, {
+      parser: "ts",
+    });
+  });
+}


### PR DESCRIPTION
I kept forgetting to add `defineTest` statements when I added a new input/output. This PR adds a utility method to auto-discover them.